### PR TITLE
Feature: Allow listening to many topics

### DIFF
--- a/MotionDetector.ts
+++ b/MotionDetector.ts
@@ -31,7 +31,10 @@ export class MotionDetector {
   listen(onMotion: (motion: boolean, id: number, topic: string) => void) {
     this.cam.on('event', (message: NotificationMessage) => {
       if (this.topics.includes(message?.topic?._)) {
-        const motion = message.message.message.data.simpleItem.$.Value;
+        const simpleItem = message.message.message.data.simpleItem;
+        const motion = (
+          simpleItem instanceof Array ? simpleItem[0] : simpleItem
+        ).$.Value;
         if (motion !== this.lastIsMotion) {
           this.lastIsMotion = motion;
           onMotion(motion, this.id, message.topic._);

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "license": "ISC",
   "devDependencies": {
     "@types/node": "^15.0.1",
-    "@typescript-eslint/eslint-plugin": "^2.31.0",
-    "@typescript-eslint/parser": "^2.31.0",
+    "@typescript-eslint/eslint-plugin": "^3.0.0",
+    "@typescript-eslint/parser": "^3.0.0",
     "eslint": "^7.0.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An implementation of Node.js that detects the events of your camera that works with the onvif protocol",
   "main": "dist/index.js",
   "scripts": {
+    "build": "tsc --build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/types/onvif.d.ts
+++ b/types/onvif.d.ts
@@ -10,13 +10,16 @@ declare module 'onvif' {
         $: object;
         source: object;
         data: {
-          simpleItem: {
-            $: {
-              Value: boolean;
-            };
-          };
+          simpleItem: SimpleItem | Array<SimpleItem>;
         };
       };
+    };
+  }
+
+  interface SimpleItem {
+    $: {
+      Name: string;
+      Value: boolean;
     };
   }
 


### PR DESCRIPTION
While using Shinobi, I've noticed that not all my cameras trigger the ONVIF event. This led me to this project and encouraged me to suggest some changes:
1. Proper alert processing when SimpleItem is actually an array of SimpleItems
2. Listening to multiple topics. I guess adding more topics as defaults may cause unexpected behavior in existing implementations, so there is an optional parameter to pass topics to listen to. If MotionDetector is created without it, everything should work as before.